### PR TITLE
Proxy configuration

### DIFF
--- a/components/article-list-item.js
+++ b/components/article-list-item.js
@@ -1,38 +1,41 @@
 import React from 'react';
 import Link from 'next/link';
 import { string } from 'prop-types';
+import absoluteUrl from 'next-absolute-url'
 
 const Item = (props) =>{
   return (
     <div className="card">
       <Link href="blog/a/[slug]" as={`/blog/a/${props.slug}`}>
-        <div className="columns">
-          <div className="column is-half">
-            <figure className="image">
-              <img src={props.thumbnail} alt="Placeholder image" />
-            </figure>
-          </div>
-          <div className="card-content">
-            <h3 className="title is-5">{ props.title }</h3>
-            <div className="article-meta">
-              <span>Category: </span><strong>{ props.category }</strong>
-              <span>Author: </span><strong>{ props.author }</strong>
+        <a>
+          <div className="columns">
+            <div className="column is-half">
+              <figure className="image">
+                <img src={ props.thumbnail } alt="Placeholder image" />
+              </figure>
             </div>
-            <div className="content">
-              <p>{ props.excerpt }</p>
-            </div>
-            <div className="level">
-              <div className="level-left"></div>
-              <div className="level-right">
-                <div className="level-item">
-                  <a href="/" className="readmore">
-                    read more...
-                  </a>
+            <div className="card-content">
+              <h3 className="title is-5">{ props.title }</h3>
+              <div className="article-meta">
+                <span>Category: </span><strong>{ props.category }</strong>
+                <span>Author: </span><strong>{ props.author }</strong>
+              </div>
+              <div className="content">
+                <p>{ props.excerpt }</p>
+              </div>
+              <div className="level">
+                <div className="level-left"></div>
+                <div className="level-right">
+                  <div className="level-item">
+                    <span className="readmore">
+                      read more...
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
+        </a>
       </Link>
       <style jsx>{`
         .article-meta {
@@ -89,4 +92,3 @@ Item.propTypes = {
 };
 
 export default Item;
-

--- a/components/article-list-item.js
+++ b/components/article-list-item.js
@@ -5,7 +5,7 @@ import { string } from 'prop-types';
 const Item = (props) =>{
   return (
     <div className="card">
-      <Link href="/a/[slug]" as={`/a/${props.slug}`}>
+      <Link href="blog/a/[slug]" as={`/blog/a/${props.slug}`}>
         <div className="columns">
           <div className="column is-half">
             <figure className="image">

--- a/components/article-list.js
+++ b/components/article-list.js
@@ -8,11 +8,12 @@ const List = (props) =>{
       {props.articles.map(({id, attributes}) => (
         <ArticleListItem
           key={id}
+          id={id}
           title={attributes.title}
           excerpt={attributes.excerpt}
           slug={attributes.slug}
           category='Web development'
-          thumbnail={attributes.thumbnail.small}
+          thumbnail={attributes.thumbnail.small.replace('https://driggl-prod.s3.eu-central-1.amazonaws.com', '/api/images')}
           author="Sebastian Wilgosz"
         />
       ))}

--- a/components/head.js
+++ b/components/head.js
@@ -6,7 +6,8 @@ const defaultDescription = '';
 const defaultOGURL = '';
 const defaultOGImage = '';
 const defaultAuthor = 'Driggl - https://driggl.com';
-const defaultOGType = 'website'
+const defaultOGType = 'website';
+const defaultSiteName = 'Driggl - Modern Web Development';
 
 const Head = props => (
   <NextHead>
@@ -21,9 +22,10 @@ const Head = props => (
     <meta name="author" content={props.author || defaultAuthor} />
     <link rel="icon" href="/favicon.ico" />
 
+    <meta property="og:site_name" content={props.siteName || defaultSiteName} />
     <meta property="og:url" content={props.url || defaultOGURL} />
     <meta property="og:title" content={props.ogTitle || props.title || ''} />
-    <meta property="og:type" content={props.ogType || defaultOGType} />
+    <meta property="fb:app_id" content={process.env.FB_APP_ID} />
 
     <meta
       property="og:description"
@@ -33,9 +35,26 @@ const Head = props => (
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
+    <meta property="og:type" content={props.ogType || defaultOGType} />
+    {
+      props.ogType == "article" ? (
+        <meta property="article:author" content="https://www.facebook.com/sebastian.wilgosz" />
+      ) : null
+    }
+    {
+      props.ogType == "article" ? (
+        <meta property="article:publisher" content="https://www.facebook.com/driggl" />
+      ) : null
+    }
+
+    <meta name="twitter:title" content={props.twitterTitle || props.OGTitle || props.title} />
     <meta name="twitter:site" content={props.twitterSite || props.url || defaultOGURL} />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:image" content={props.ogImage || defaultOGImage} />
+    <meta
+      name="twitter:description"
+      content={props.twitterDescription || props.OGDescription || props.description || defaultDescription}
+    />
 
   </NextHead>
 );

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bulma": "^0.8.0",
     "isomorphic-unfetch": "^3.0.0",
     "next": "^9.1.6",
+    "next-absolute-url": "^1.2.2",
     "node-sass": "^4.13.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/pages/api/articles.js
+++ b/pages/api/articles.js
@@ -1,0 +1,8 @@
+import fetch from 'isomorphic-unfetch';
+
+export default async (req, res) => {
+  const url = req.url.replace("/api/", "https://api.sourcerio.com/v1/blogs/driggl/");
+  const newres = await fetch(url);
+  const data = await newres.json();
+  res.json(data);
+};

--- a/pages/api/articles/[slug].js
+++ b/pages/api/articles/[slug].js
@@ -1,0 +1,8 @@
+import fetch from 'isomorphic-unfetch';
+
+export default async (req, res) => {
+  const url = req.url.replace("/api/", "https://api.sourcerio.com/v1/blogs/driggl/");
+  const newres = await fetch(url);
+  const data = await newres.json();
+  res.json(data);
+};

--- a/pages/api/images/[...path].js
+++ b/pages/api/images/[...path].js
@@ -1,0 +1,8 @@
+import fetch from 'isomorphic-unfetch';
+
+export default async (req, res) => {
+  const url = req.url.replace('/api/images', 'https://driggl-prod.s3.eu-central-1.amazonaws.com')
+  const newres = await fetch(url);
+
+  res.send(newres.body);
+}

--- a/pages/blog/a/[slug].js
+++ b/pages/blog/a/[slug].js
@@ -23,7 +23,7 @@ const Article = ({article}) => {
           )
         }
         ogType="website"
-        url="https://driggl.com/blog"
+        url={ `https://driggl.com/blog/a/${article.attributes.slug}`}
         twitterSite="@drigglweb"
         twitterCreator="@sebwilgosz"
         twitterTitle={article.attributes.title}

--- a/pages/blog/a/[slug].js
+++ b/pages/blog/a/[slug].js
@@ -3,7 +3,7 @@ import Head from 'components/head';
 import Nav from 'components/nav';
 import 'assets/sass/general.sass';
 import fetch from 'isomorphic-unfetch';
-import { useRouter } from 'next/router';
+import absoluteUrl from 'next-absolute-url'
 
 const Article = ({article}) => {
   return (
@@ -17,10 +17,10 @@ const Article = ({article}) => {
         ogType="article"
         ogDescription={article.attributes.excerpt}
         ogImage={
-          article.attributes.thumbnail.sharing //.replace(
-            // "https://driggl-prod.s3.eu-central-1.amazonaws.com",
-            // "/images"
-          // )
+          article.attributes.thumbnail.sharing.replace(
+            "https://driggl-prod.s3.eu-central-1.amazonaws.com",
+            "/api/images"
+          )
         }
         ogType="website"
         url="https://driggl.com/blog"
@@ -36,20 +36,20 @@ const Article = ({article}) => {
         style={{
           'backgroundImage':
             'url(' +
-            article.attributes.thumbnail.full + //.replace(
-              // 'https://driggl-prod.s3.eu-central-1.amazonaws.com',
-        //       '/images'
-        //     ) +
+            article.attributes.thumbnail.full.replace(
+              'https://driggl-prod.s3.eu-central-1.amazonaws.com',
+              '/api/images'
+            ) +
             ')'
         }}
       >
         <div className="cover social">
           <img
             src={
-              article.attributes.thumbnail.sharing //.replace(
-                // 'https://driggl-prod.s3.eu-central-1.amazonaws.com',
-                // '/images'
-              // )
+              article.attributes.thumbnail.sharing.replace(
+                'https://driggl-prod.s3.eu-central-1.amazonaws.com',
+                '/api/images'
+              )
               }
           />
         </div>
@@ -134,10 +134,10 @@ const Article = ({article}) => {
 
 Article.getInitialProps = async function(context) {
   const { slug } = context.query
-  const res = await fetch(`https://api.sourcerio.com/v1/blogs/driggl/articles/${slug}`);
+  const { origin } = absoluteUrl(context.req)
+  var url = new URL(`/api/articles/${slug}`, origin)
+  const res = await fetch(url.toString());
   const data = await res.json();
-  console.log("fetched");
-  console.log(data.data);
 
   return {
     article: data.data

--- a/pages/blog/a/[slug].js
+++ b/pages/blog/a/[slug].js
@@ -1,0 +1,147 @@
+import React from 'react'
+import Head from 'components/head';
+import Nav from 'components/nav';
+import 'assets/sass/general.sass';
+import fetch from 'isomorphic-unfetch';
+import { useRouter } from 'next/router';
+
+const Article = ({article}) => {
+  return (
+    <div>
+      <Head
+        title={ `${article.attributes.title} | Driggl - Modern web development` }
+        description={article.attributes.excerpt}
+        author="Sebastian Wilgosz"
+
+        ogTitle={article.attributes.title}
+        ogType="article"
+        ogDescription={article.attributes.excerpt}
+        ogImage={
+          article.attributes.thumbnail.sharing //.replace(
+            // "https://driggl-prod.s3.eu-central-1.amazonaws.com",
+            // "/images"
+          // )
+        }
+        ogType="website"
+        url="https://driggl.com/blog"
+        twitterSite="@drigglweb"
+        twitterCreator="@sebwilgosz"
+        twitterTitle={article.attributes.title}
+        twitterDescription={article.attributes.excerpt}
+      />
+
+      <Nav />
+      <section
+        className="hero"
+        style={{
+          'backgroundImage':
+            'url(' +
+            article.attributes.thumbnail.full + //.replace(
+              // 'https://driggl-prod.s3.eu-central-1.amazonaws.com',
+        //       '/images'
+        //     ) +
+            ')'
+        }}
+      >
+        <div className="cover social">
+          <img
+            src={
+              article.attributes.thumbnail.sharing //.replace(
+                // 'https://driggl-prod.s3.eu-central-1.amazonaws.com',
+                // '/images'
+              // )
+              }
+          />
+        </div>
+        <div className="hero-body">
+          <div className="container has-text-centered">
+            <h1 className="title">
+              { article.attributes.title }
+            </h1>
+          </div>
+        </div>
+      </section>
+      <div className="section main">
+        <div className="container">
+          <div className="columns">
+            <div className="column is-hidden-touch is-one-quarter-desktop" />
+            <div className="column is-two-third-tablet is-one-half-desktop">
+              <div className="article-meta">
+                <span>Category: </span><strong>Web development</strong>
+                <span>Author: </span><strong>Sebastian Wilgosz</strong>
+              </div>
+              <div
+                className="content is-spaced"
+                dangerouslySetInnerHTML={{
+                __html: article.attributes.content
+              }}
+              />
+              <div className="comments">
+                {/* <vue-disqus
+                  shortname="driggl"
+                  :identifier="'article-' + article.id"
+                  :url="'https://driggl.com/blog/a/' + article.slug"
+                  :title="article.title"
+                /> */}
+              </div>
+            </div>
+            <aside className="column is-one-third-tablet is-one-quarter-desktop">
+              <section className="header">
+                {/* <email-subscription-form /> */}
+              </section>
+            </aside>
+          </div>
+        </div>
+      </div>
+      <style jsx>{`
+        .main {
+          padding: 40px 0;
+        }
+        .main .content {
+          padding-top: 30px;
+        }
+
+        .hero {
+          height: 400px;
+          background-position: center;
+        }
+        .hero .container {
+          max-width: 700px;
+          margin: auto;
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+          justify-content: center;
+        }
+        .hero .title, .subtitle {
+          color: #fff; //$white;
+        }
+
+        .hero-body {
+          background-color: rgba(0,0,0,0.75);
+        }
+
+        .cover.social {
+          overflow: hidden;
+          width: 1px;
+          height: 1px;
+          float: left;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+Article.getInitialProps = async function(context) {
+  const { slug } = context.query
+  const res = await fetch(`https://api.sourcerio.com/v1/blogs/driggl/articles/${slug}`);
+  const data = await res.json();
+  console.log("fetched");
+  console.log(data.data);
+
+  return {
+    article: data.data
+  };
+};
+
+export default Article;

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -4,6 +4,8 @@ import Nav from '../../components/nav';
 import '../../assets/sass/general.sass';
 import ArticleList from '../../components/article-list'
 import fetch from 'isomorphic-unfetch';
+import absoluteUrl from 'next-absolute-url'
+
 
 const Blog = (props) => {
   return (
@@ -43,10 +45,11 @@ const Blog = (props) => {
   );
 };
 
-Blog.getInitialProps = async function() {
-  const res = await fetch('https://api.sourcerio.com/v1/blogs/driggl/articles');
+Blog.getInitialProps = async function(context) {
+  const { origin } = absoluteUrl(context.req)
+  var url = new URL("/api/articles?page[number]=1&page[size]=10", origin)
+  const res = await fetch(url.toString());
   const data = await res.json();
-  console.log(`Show data fetched. Count: ${data.data.length}`);
 
   return {
     articles: data.data.map(entry => entry)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4300,6 +4300,11 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
+next-absolute-url@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/next-absolute-url/-/next-absolute-url-1.2.2.tgz#9aba5adcee8effcffd63271d99e13213ad04c23b"
+  integrity sha512-Z2+LZXQTthhw2je9u4eq8QWXxXd57a6b54x9exBfQX4Dct6YxaMjcXZWNLHd9AOlCue84EsMpdSGP7wACqUnPg==
+
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"


### PR DESCRIPTION
### Overview

Configured basic proxy, so Image and PAI hosts are now hidden from the browser.

images are available under `/api/images/*`
api requests for articles are available under `/api/articles` and `/api/aritcles/[slug]`

### Notes

- next-absolute-url was needed to add support for both server and client requests
- as this is mostly a test, I did not use Redux, so I just replace paths in the view components (to be refactored later)

### Todos

- we can prettify the image urls much more when we'll use Redux (i.e `/api/images/articles/[:slug]/small.jpg` - and fetch the thumbnail in the API handler